### PR TITLE
Change the style of the Render button to match Logseq's CSS theme

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,18 +50,8 @@ const main = () => {
     });
 
     logseq.provideStyle(`
-      .renderBtn {
-        border: 1px solid black;
-        border-radius: 8px;
-        padding: 3px;
-        font-size: 80%;
-        background-color: white;
-        color: black;
-      }
-
-      .renderBtn:hover {
-        background-color: black;
-        color: white;
+      .render-btn {
+          border: 1px dashed var(--ls-border-color);
       }
     `);
 
@@ -69,7 +59,7 @@ const main = () => {
       key: `${plantumlId}`,
       slot,
       reset: true,
-      template: `<button data-on-click="show" class="renderBtn">Render</button>`,
+      template: `<button data-on-click="show" class="button render-btn">Render</button>`,
     });
   });
 };


### PR DESCRIPTION
The changes update the class of the button to '.button' and add a dotted border color '--ls-border-color' from Logseq's CSS.

Tested in the default light and dark themes.

_dark default:_ 
<img width="410" alt="image" src="https://github.com/user-attachments/assets/fb0b460a-cd2b-4f17-b6cd-c772edcdc4c7">
_dark hovered:_ 
<img width="407" alt="image" src="https://github.com/user-attachments/assets/55ac5972-0b5a-4b21-805b-201d6432f598">
_light default:_ 
<img width="414" alt="image" src="https://github.com/user-attachments/assets/5fc8cb15-88f2-4229-81c7-a9ea4ea90bfd">
_light hovered:_ 
<img width="411" alt="image" src="https://github.com/user-attachments/assets/152a3233-22df-46af-a1cc-68f921463efc">
